### PR TITLE
Adding exception to when number is negative

### DIFF
--- a/.ipynb_checkpoints/sqrt-checkpoint.py
+++ b/.ipynb_checkpoints/sqrt-checkpoint.py
@@ -13,9 +13,7 @@ import math
 
 opt = docopt(__doc__)
 
-def main(number): 
-if number < 0:
-  raise Exception("n should not a positive number")
+def main(number):
   number = int(number)
   print(math.sqrt(number))
     


### PR DESCRIPTION
If the number is less than 0, then it would output the exception rather than computing it's square root.